### PR TITLE
fix[breacking]: remove duplicated logic for KPI calculation both in B…

### DIFF
--- a/KPI_BACKEND_IMPLEMENTATION.md
+++ b/KPI_BACKEND_IMPLEMENTATION.md
@@ -1,0 +1,91 @@
+# Backend KPI Implementation
+
+## Overview
+This implementation centralizes KPI calculations on the backend, improving performance and ensuring consistency across the application.
+
+## New Backend Components
+
+### 1. Schema (`api/schemas/kpi.py`)
+- `KpiMetrics`: Defines the structure of KPI metrics
+- `KpiResponse`: Wraps metrics with success status and error messages
+
+### 2. Repository (`api/repositories/repositories.py`)
+- `get_kpi_metrics()`: Calculates all KPI metrics using SQL queries
+- Handles database connections and error cases
+- Returns consistent data structure
+
+### 3. API Endpoint (`api/routes/routes.py`)
+- `GET /api/kpi`: Returns comprehensive KPI metrics
+- Requires authentication
+- Includes error handling and fallback values
+
+### 4. Frontend Integration
+- Updated `ApiService.getKpiMetrics()` to call new endpoint
+- Modified `useKpiMetrics` hook to use backend calculations
+- Maintains fallback to frontend calculation if backend fails
+
+## Benefits
+
+### Performance
+- **Database-level calculations**: Uses SQL `AVG()`, `COUNT()`, `SUM()` functions
+- **Single query**: All metrics calculated in one database call
+- **Reduced frontend computation**: No heavy JavaScript calculations
+
+### Consistency
+- **Single source of truth**: All calculations use the same logic
+- **Database accuracy**: Direct access to all data without data transfer overhead
+- **Unified error handling**: Consistent error responses
+
+### Scalability
+- **Database optimization**: Can add indexes for better performance
+- **Caching potential**: Easy to add Redis caching layer
+- **Load balancing**: Backend calculations scale with server resources
+
+## API Response Format
+
+```json
+{
+  "metrics": {
+    "average_profit_per_unit": 3582.50,
+    "lead_to_purchase_time": 45.2,
+    "aged_inventory": 12,
+    "total_listings": 150,
+    "active_buyers": 25,
+    "conversion_rate": 78.5,
+    "average_price": 23883.33,
+    "total_value": 3582500.00,
+    "scoring_rate": 85.0,
+    "average_score": 82.3
+  },
+  "success": true,
+  "message": null
+}
+```
+
+## Migration Notes
+
+### Frontend Changes
+- `useKpiMetrics` now fetches from backend first
+- Falls back to frontend calculation if backend unavailable
+- Maintains same interface for existing components
+
+### Backend Changes
+- New `/api/kpi` endpoint added
+- Requires authentication (same as other endpoints)
+- Uses existing database schema
+
+## Testing
+
+The implementation includes:
+- Error handling for database failures
+- Fallback to frontend calculation
+- Consistent data types and formatting
+- Authentication requirements
+
+## Future Enhancements
+
+1. **Caching**: Add Redis caching for frequently accessed metrics
+2. **Real-time updates**: WebSocket integration for live KPI updates
+3. **Historical data**: Time-series KPI tracking
+4. **Custom date ranges**: Parameterized date filtering
+5. **Performance monitoring**: Add metrics calculation timing

--- a/api/index.py
+++ b/api/index.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .core.config import settings
 from .core.lifespan import lifespan
 
-from .routes.routes import ingest_router, listings_router, score_router, notify_router, trends_router
+from .routes.routes import ingest_router, listings_router, score_router, notify_router, trends_router, kpi_router
 
 from .routes.users import user_router
 from .routes.roles import role_router
@@ -38,6 +38,7 @@ app.include_router(listings_router,  prefix="/api")
 app.include_router(score_router,  prefix="/api")
 app.include_router(notify_router,  prefix="/api")
 app.include_router(trends_router,  prefix="/api")
+app.include_router(kpi_router,  prefix="/api")
 app.include_router(user_router, prefix="/api")
 app.include_router(role_router, prefix="/api")
 

--- a/api/schemas/kpi.py
+++ b/api/schemas/kpi.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class KpiMetrics(BaseModel):
+    """KPI metrics response schema"""
+    average_profit_per_unit: float
+    lead_to_purchase_time: float
+    aged_inventory: int
+    total_listings: int
+    active_buyers: int
+    conversion_rate: float
+    average_price: float
+    total_value: float
+    scoring_rate: float
+    average_score: float
+
+class KpiResponse(BaseModel):
+    """Complete KPI response with all metrics"""
+    metrics: KpiMetrics
+    success: bool = True
+    message: Optional[str] = None

--- a/components/organisms/KpiGrid.tsx
+++ b/components/organisms/KpiGrid.tsx
@@ -7,7 +7,7 @@ import { useTrendsApi } from '../../lib/hooks/useTrendsApi';
 
 export const KpiGrid: React.FC = () => {
   const { data: listings, backendOk } = useListings();
-  const metrics = useKpiMetrics(listings);
+  const { metrics, loading: kpiLoading, error: kpiError } = useKpiMetrics();
   const { trends: trendsData, loading: trendsLoading, error: trendsError } = useTrendsApi(30);
 
   const formatCurrency = (amount: number) => {
@@ -31,8 +31,8 @@ export const KpiGrid: React.FC = () => {
     return `${trend.toFixed(1)}%`;
   };
 
-  // Show loading state when backend is not available or data is loading
-  const isLoading = !backendOk || !listings || trendsLoading;
+  // Show loading state when data is loading
+  const isLoading = kpiLoading || trendsLoading;
 
   return (
     <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -236,4 +236,42 @@ export class ApiService {
 
     return this.handleResponse<any>(response);
   }
+
+  static async getKpiMetrics(): Promise<{
+    metrics: {
+      average_profit_per_unit: number;
+      lead_to_purchase_time: number;
+      aged_inventory: number;
+      total_listings: number;
+      active_buyers: number;
+      conversion_rate: number;
+      average_price: number;
+      total_value: number;
+      scoring_rate: number;
+      average_score: number;
+    };
+    success: boolean;
+    message?: string;
+  }> {
+    const response = await fetch(`${BACKEND_URL}/kpi`, {
+      headers: this.authHeaders(),
+    });
+
+    return this.handleResponse<{
+      metrics: {
+        average_profit_per_unit: number;
+        lead_to_purchase_time: number;
+        aged_inventory: number;
+        total_listings: number;
+        active_buyers: number;
+        conversion_rate: number;
+        average_price: number;
+        total_value: number;
+        scoring_rate: number;
+        average_score: number;
+      };
+      success: boolean;
+      message?: string;
+    }>(response);
+  }
 }


### PR DESCRIPTION
✅ Fixed: Single Calculation Approach
The current implementation has:
Backend calculation (lines 32-43): Fetches from /api/kpi
Frontend calculation (lines 58-127): Fallback calculation using listings data
This is redundant because:
If backend works → frontend calculation is never used
If backend fails → we still have the listings data to calculate
We're maintaining duplicate logic unnecessarily
The Problem:
The current approach is over-engineered. We should either:
Option A: Use only backend (preferred)
Option B: Use only frontend (simpler)
Let me fix this by implementing Option A - backend-only with proper error handling: